### PR TITLE
24 Annotations on create and update

### DIFF
--- a/graphql-api-generator/utils/utils.py
+++ b/graphql-api-generator/utils/utils.py
@@ -354,6 +354,19 @@ def extend_connect(schema: GraphQLSchema, _type: GraphQLType, field_type: GraphQ
             make += f'{create_field} : {create_implementing_type} '
     else:
         make += f'create: {create_name} '
+        
+    # Get annotations
+    edge_from = f'{capitalize(field_name)}EdgeFrom{_type.name}'
+    annotate_input = f'_InputToAnnotate{edge_from}'
+    annotations = get_field_annotations(_type.fields[field_name])
+
+    if len(annotations) > 0:
+        # Make sure the annotation type actually exists first, and prevent us from defining it multiple times
+        if annotate_input not in schema.type_map:
+            schema = add_to_schema(schema, f'input {annotate_input}{{{annotations}}}')
+
+        make += f'annotations: {annotate_input}'
+
     make += '}'
     schema = add_to_schema(schema, make)
     return schema
@@ -653,7 +666,10 @@ def add_input_to_create_edge_objects(schema: GraphQLSchema):
 
                 if len(annotations) > 0:
                     make += f'input {edge_input} {{sourceID: ID! targetID: ID! annotations: {annotate_input} }}\n'
-                    make += f'input {annotate_input}{{{annotations}}}\n'
+                    
+                    # Make sure the annotation type actually exists first, and prevent us from defining it multiple times
+                    if annotate_input not in schema.type_map:
+                        make += f'input {annotate_input}{{{annotations}}}\n'
                 else:
                     make += f'input {edge_input} {{sourceID: ID! targetID: ID!}}\n'
 

--- a/graphql-server/drivers/arangodb/driver.js
+++ b/graphql-server/drivers/arangodb/driver.js
@@ -240,6 +240,28 @@ function getObjectOrInterfaceFields(type) {
     return keys;
 }
 
+/**
+ * Get the annotations of an edge and convert them to string to be used in insert operations
+ * Would have prefered using createEdge, but we seem unable to pass a properly accesible "context variable"._id as parameter
+ * @param annotations
+ * @returns String
+ */
+function getAnnotations(annotations) {
+    // Remeber that annotations should already have passed through getScalarsAndEnums
+    // So injections on field should not be possible
+    // The values need to be checked separatly.
+    let ret = '';
+    for (let field in annotations) {
+        if (typeof annotations[field] === 'string') {
+            // Treat strings as strings
+            ret += `, ${field}: "${annotations[field]}"`;
+        }
+        else
+            ret += `, ${field}: ${annotations[field]}`;
+    }
+    return ret;
+}
+
 // ----------------------------------------------------------
 
 async function getEdge(parent, args, info){
@@ -301,15 +323,15 @@ async function getEdge(parent, args, info){
 /*
 TODO: We should probably call the createEdge function here (when we've defined it).
  */
-async function create(isRoot, ctxt, data, returnType, info){
+async function create(isRoot, ctxt, data, returnType, info) {
     // define transaction object
-    if(ctxt.trans === undefined) ctxt.trans = initTransaction();
+    if (ctxt.trans === undefined) ctxt.trans = initTransaction();
 
     // is root op and mutatation is already queued
-    if(isRoot && ctxt.trans.queue[info.path.key]){
-        if(ctxt.trans.open) await executeTransaction(ctxt);
-        if(ctxt.trans.error){
-            if(ctxt.trans.errorReported) return null;
+    if (isRoot && ctxt.trans.queue[info.path.key]) {
+        if (ctxt.trans.open) await executeTransaction(ctxt);
+        if (ctxt.trans.error) {
+            if (ctxt.trans.errorReported) return null;
             ctxt.trans.errorReported = true;
             throw ctxt.trans.error;
         }
@@ -338,18 +360,26 @@ async function create(isRoot, ctxt, data, returnType, info){
 
     // for edges
     let ob = getTypesAndInterfaces(data, returnType);
-    for(let fieldName in ob){
+    for (let fieldName in ob) {
         let innerFieldType = graphql.getNamedType(returnType.getFields()[fieldName].type);
         let edge = getEdgeCollectionName(returnType.name, fieldName);
         ctxt.trans.write.add(edge);
         let edgeCollection = asAQLVar(`db.${edge}`);
         let values = Array.isArray(ob[fieldName]) ? ob[fieldName] : [ob[fieldName]]; // treat as list even if only one value is present
 
-        for(let i in values){
+        for (let i in values) {
             let value = values[i];
             console.log(value);
-            if(graphql.isInterfaceType(innerFieldType)){ // interface
-                if(value['connect']){
+
+            // Prepare annotations
+            let annotations = null;
+            if (value['annotations']) {
+                annotations = getScalarsAndEnums(value['annotations'], info.schema.getType("_InputToAnnotate" + edge));
+                annotations['_creationDate'] = date.valueOf();
+            }
+
+            if (graphql.isInterfaceType(innerFieldType)) { // interface
+                if (value['connect']) {
                     validateType(ctxt, value['connect'], innerFieldType, info.schema);
                     let typeToConnect = value['connect'].split('/')[0];
                     // add edge
@@ -361,10 +391,14 @@ async function create(isRoot, ctxt, data, returnType, info){
                 } else {
                     // create
                     let key = Object.keys(value)[0];
+                    if (key == "annotations") {
+                        // In case the user actually specifies the annotations before the edge
+                        key = Object.keys(value)[1];
+                    }
                     let typeToCreate = key.replace(/^create(.+)$/, '$1');
-                    let to = asAQLVar(getVar(ctxt)); // reference to the object to be added
+                    let to = asAQLVar(getVar(ctxt)); // reference to the object to be addedd
                     await create(false, ctxt, value[key], info.schema.getType(typeToCreate), info);
-                    ctxt.trans.code.push(`db._query(aql\`INSERT {_from: ${from}._id, _to: ${to}._id } IN ${edgeCollection} RETURN NEW\`);`);
+                    ctxt.trans.code.push(`db._query(aql\`INSERT {_from: ${from}._id, _to: ${to}._id ${getAnnotations(annotations)}} IN ${edgeCollection} RETURN NEW\`);`);
                 }
             } else { // type
                 if (value['connect']) {
@@ -376,10 +410,11 @@ async function create(isRoot, ctxt, data, returnType, info){
                     ctxt.trans.code.push(`} else { `);
                     ctxt.trans.code.push(`   throw "${value['connect']} does not exist in ${typeToConnect}";`);
                     ctxt.trans.code.push(`}`);
-                } else {// create
+                } else {// 
                     let to = asAQLVar(getVar(ctxt)); // reference to the object to be added
                     await create(false, ctxt, value['create'], innerFieldType, info);
-                    ctxt.trans.code.push(`db._query(aql\`INSERT {_from: ${from}._id, _to: ${to}._id } IN ${edgeCollection} RETURN NEW\`);`);
+                    console.log(innerFieldType.name);
+                    ctxt.trans.code.push(`db._query(aql\`INSERT {_from: ${from}._id, _to: ${to}._id ${getAnnotations(annotations)}} IN ${edgeCollection} RETURN NEW\`);`);
                 }
             }
         }
@@ -389,7 +424,7 @@ async function create(isRoot, ctxt, data, returnType, info){
     addFinalDirectiveChecksForType(ctxt, returnType, aql`${asAQLVar(resVar)}._id`, info.schema);
 
     // overwrite the current action
-    if(isRoot) {
+    if (isRoot) {
         ctxt.trans.code.push(`result['${info.path.key}'] = ${resVar};`); // add root result
         ctxt.trans.queue[info.path.key] = true; // indicate that this mutation op has been added to the transaction
         getVar(ctxt); // increment varCounter
@@ -549,15 +584,15 @@ function validateType(ctxt, id, type, schema){
     }
 }
 
-async function update(isRoot, ctxt, id, data, returnType, info){
+async function update(isRoot, ctxt, id, data, returnType, info) {
     // define transaction object
-    if(ctxt.trans === undefined) ctxt.trans = initTransaction();
+    if (ctxt.trans === undefined) ctxt.trans = initTransaction();
 
     // is root op and mutation is already queued
-    if(isRoot && ctxt.trans.queue[info.path.key]){
-        if(ctxt.trans.open) await executeTransaction(ctxt);
-        if(ctxt.trans.error){
-            if(ctxt.trans.errorReported) return null;
+    if (isRoot && ctxt.trans.queue[info.path.key]) {
+        if (ctxt.trans.open) await executeTransaction(ctxt);
+        if (ctxt.trans.error) {
+            if (ctxt.trans.errorReported) return null;
             ctxt.trans.errorReported = true;
             throw ctxt.trans.error;
         }
@@ -569,24 +604,24 @@ async function update(isRoot, ctxt, id, data, returnType, info){
     // 3) Add key check to transaction
     let keyName = getKeyName(returnType.name);
     let keyType = info.schema["_typeMap"][keyName];
-    if(keyType){
+    if (keyType) {
         try {
             let collection = db.collection(returnType);
             const cursor = await db.query(aql`FOR i IN ${collection} FILTER(i._id == ${id}) RETURN i`);
             let doc = await cursor.next();
-            if(doc == undefined){
+            if (doc == undefined) {
                 throw new ApolloError(`ID ${id} is not a document in the type ${returnType}`);
             }
 
             let key = {};
-            for(let f in keyType._fields){
+            for (let f in keyType._fields) {
                 key[f] = doc[f];
-                if(data[f] !== undefined){
+                if (data[f] !== undefined) {
                     key[f] = data[f];
                 }
             }
             validateKey(ctxt, key, returnType, info.schema, id);
-        } catch(err) {
+        } catch (err) {
             throw new ApolloError(err);
         }
     }
@@ -619,6 +654,13 @@ async function update(isRoot, ctxt, id, data, returnType, info){
         for (let i in values) {
             let value = values[i];
 
+            // Prepare annotations
+            let annotations = null;
+            if (value['annotations']) {
+                annotations = getScalarsAndEnums(value['annotations'], info.schema.getType("_InputToAnnotate" + edge));
+                annotations['_creationDate'] = date.valueOf();
+            }
+
             if (graphql.isInterfaceType(nestedReturnType)) {
                 // interface field
                 if (value['connect']) {
@@ -630,11 +672,11 @@ async function update(isRoot, ctxt, id, data, returnType, info){
                     // add edge
                     if (!disableEdgeValidation) { // check the database
                         ctxt.trans.code.push(`if(db._collection('${typeToConnect}').exists('${value['connect']}')){`);
-                        ctxt.trans.code.push(`db._query(aql\`INSERT {_from: "${id}", _to: "${value['connect']}" } IN ${edgeCollection} RETURN NEW\`);`);
+                        ctxt.trans.code.push(`db._query(aql\`INSERT {_from: "${id}", _to: "${value['connect']}" ${getAnnotations(annotations)}} IN ${edgeCollection} RETURN NEW\`);`);
                         ctxt.trans.code.push(`} else { throw "${value['connect']} does not exist in ${typeToConnect}"; }`);
                     } else {
                         console.warn(`Adding connection to ${value['connect']} in ${edge} without validating ID`);
-                        ctxt.trans.code.push(`db._query(aql\`INSERT {_from: "${id}", _to: "${value['connect']}" } IN ${edgeCollection} RETURN NEW\`);`);
+                        ctxt.trans.code.push(`db._query(aql\`INSERT {_from: "${id}", _to: "${value['connect']}" ${getAnnotations(annotations)}} IN ${edgeCollection} RETURN NEW\`);`);
                     }
                 } else {
                     // create
@@ -658,17 +700,17 @@ async function update(isRoot, ctxt, id, data, returnType, info){
                     // add edge
                     if (!disableEdgeValidation) { // check the database
                         ctxt.trans.code.push(`if(db._collection('${typeToConnect}').exists('${value['connect']}')){`);
-                        ctxt.trans.code.push(`db._query(aql\`INSERT {_from: "${id}", _to: "${value['connect']}" } IN ${edgeCollection} RETURN NEW\`);`);
+                        ctxt.trans.code.push(`db._query(aql\`INSERT {_from: "${id}", _to: "${value['connect']}" ${getAnnotations(annotations)}} IN ${edgeCollection} RETURN NEW\`);`);
                         ctxt.trans.code.push(`} else { throw "${value['connect']} does not exist in ${typeToConnect}"; }`);
                     } else {
                         console.warn(`Adding connection to ${value['connect']} in ${edge} without validating ID`);
-                        ctxt.trans.code.push(`db._query(aql\`INSERT {_from: "${id}", _to: "${value['connect']}" } IN ${edgeCollection} RETURN NEW\`);`);
+                        ctxt.trans.code.push(`db._query(aql\`INSERT {_from: "${id}", _to: "${value['connect']}" ${getAnnotations(annotations)}} IN ${edgeCollection} RETURN NEW\`);`);
                     }
                 } else {
                     // create
                     let to = asAQLVar(getVar(ctxt)); // reference to the object to be added
                     await create(false, ctxt, value['create'], nestedReturnType, info);
-                    ctxt.trans.code.push(`db._query(aql\`INSERT {_from: "${id}", _to: ${to}._id } IN ${edgeCollection} RETURN NEW\`);`);
+                    ctxt.trans.code.push(`db._query(aql\`INSERT {_from: "${id}", _to: ${to}._id ${getAnnotations(annotations)}} IN ${edgeCollection} RETURN NEW\`);`);
                 }
             }
         }
@@ -678,7 +720,7 @@ async function update(isRoot, ctxt, id, data, returnType, info){
     addFinalDirectiveChecksForType(ctxt, returnType, aql`${asAQLVar(resVar)}._id`, info.schema);
 
     // overwrite the current action
-    if(isRoot) {
+    if (isRoot) {
         ctxt.trans.code.push(`result['${info.path.key}'] = ${resVar}.new;`); // add root result
         ctxt.trans.queue[info.path.key] = true; // indicate that this mutation op has been added to the transaction
         getVar(ctxt); // increment varCounter

--- a/graphql-server/drivers/arangodb/driver.js
+++ b/graphql-server/drivers/arangodb/driver.js
@@ -396,7 +396,7 @@ async function create(isRoot, ctxt, data, returnType, info) {
                         key = Object.keys(value)[1];
                     }
                     let typeToCreate = key.replace(/^create(.+)$/, '$1');
-                    let to = asAQLVar(getVar(ctxt)); // reference to the object to be addedd
+                    let to = asAQLVar(getVar(ctxt)); // reference to the object to be added
                     await create(false, ctxt, value[key], info.schema.getType(typeToCreate), info);
                     ctxt.trans.code.push(`db._query(aql\`INSERT {_from: ${from}._id, _to: ${to}._id ${getAnnotations(annotations)}} IN ${edgeCollection} RETURN NEW\`);`);
                 }
@@ -410,10 +410,9 @@ async function create(isRoot, ctxt, data, returnType, info) {
                     ctxt.trans.code.push(`} else { `);
                     ctxt.trans.code.push(`   throw "${value['connect']} does not exist in ${typeToConnect}";`);
                     ctxt.trans.code.push(`}`);
-                } else {// 
+                } else { // create
                     let to = asAQLVar(getVar(ctxt)); // reference to the object to be added
                     await create(false, ctxt, value['create'], innerFieldType, info);
-                    console.log(innerFieldType.name);
                     ctxt.trans.code.push(`db._query(aql\`INSERT {_from: ${from}._id, _to: ${to}._id ${getAnnotations(annotations)}} IN ${edgeCollection} RETURN NEW\`);`);
                 }
             }


### PR DESCRIPTION
#24 and parts of #63 should be solved/corrected with this one. I have actually not queried the edges for their properties yet (as those queries are not implemented). The inserting the values does not crash, so I expect it to work.

I somewhat dislike the solution for this one. Would have been better to be able to call `createEdge` instead of pushing insert calls directly for each edge. I seem unable to be able to properly get (usable-) id's of fresh edge-objects into `createEdge` (into parameters specifically), and hence had to use this/the "old" method.

I also let the automatic white-space changes/corrections slip this time as I'm getting bored of editing them out after moving functions between files.

I have some very simple test cases for this if reviewer is interested (Robin?)

How to properly handle edges on updates still needs to be discussed.

@hartig @keski @keski 
