### PR TITLE
Edge requesting for #31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 **v0.1.1, released on ???**
 * New feature: Edge annotations can now be set when creating and/or updating objects. See: https://github.com/LiUGraphQL/woo.sh/issues/24
+* New feature: Incoming and outgoing edges (with annotations) can now be queried (not just the sources and targets). See: https://github.com/LiUGraphQL/woo.sh/issues/31
+* New feature: client-tests now handles edge annotations.
 * Bug fix: Default values missing from field arguments is now fixed.
 
 **v0.1.0, released on June 09, 2020**

--- a/graphql-api-generator/generator.py
+++ b/graphql-api-generator/generator.py
@@ -80,8 +80,8 @@ def run(schema: GraphQLSchema, config: dict):
         # add edge types
         if config.get('generation').get('edge_types') or config.get('generation').get('create_edge_objects'):
             schema = add_edge_objects(schema)
-        if config.get('generation').get('fields_for_edge_types'):
-            raise UnsupportedOperation('{0} is currently not supported'.format('fields_for_edge_types'))
+        if config.get('generation').get('fields_for_edge_types') or True :
+            schema = add_fields_for_edge_types(schema, config.get('generation').get('reverse_edges'))
 
         # add creation date
         if config.get('generation').get('field_for_creation_date'):

--- a/graphql-api-generator/generator.py
+++ b/graphql-api-generator/generator.py
@@ -80,7 +80,7 @@ def run(schema: GraphQLSchema, config: dict):
         # add edge types
         if config.get('generation').get('edge_types') or config.get('generation').get('create_edge_objects'):
             schema = add_edge_objects(schema)
-        if config.get('generation').get('fields_for_edge_types') or True :
+        if config.get('generation').get('fields_for_edge_types'):
             schema = add_fields_for_edge_types(schema, config.get('generation').get('reverse_edges'))
 
         # add creation date

--- a/graphql-api-generator/utils/utils.py
+++ b/graphql-api-generator/utils/utils.py
@@ -615,7 +615,7 @@ def add_object_type_filters(schema: GraphQLSchema):
                 continue
 
             named_type = get_named_type(field.type)
-            if is_enum_or_scalar(named_type) or is_interface_type(named_type) or field_name[0:9] == '_incoming' or field_name[0:9] == '_outgoing':
+            if is_enum_or_scalar(named_type) or is_interface_type(named_type) or field_name.startswith('_incoming') or field_name.startswith('_outgoing'):
                 continue
             filter_name = f'_FilterFor{capitalize(named_type.name)}'
             _filter = schema.type_map[filter_name]

--- a/graphql-api-generator/utils/utils.py
+++ b/graphql-api-generator/utils/utils.py
@@ -208,9 +208,14 @@ def add_reverse_edges(schema: GraphQLSchema):
 
             if hasattr(field_type, 'ast_node') and field_type.ast_node is not None:
                 directives = {directive.name.value: directive for directive in field_type.ast_node.directives}
-
+                
             if 'requiredForTarget' in directives:
                 directive_to_add = '@required'
+
+            if hasattr(_type, 'interfaces'):
+                for interface in _type.interfaces:
+                    if field_name in interface.fields.keys():
+                        directives = {**directives, **{directive.name.value: directive for directive in interface.fields[field_name].ast_node.directives}}
 
             if 'uniqueForTarget' in directives:
                 edge_to = _type
@@ -597,7 +602,7 @@ def add_object_type_filters(schema: GraphQLSchema):
                 continue
 
             named_type = get_named_type(field.type)
-            if is_enum_or_scalar(named_type) or is_interface_type(named_type):
+            if is_enum_or_scalar(named_type) or is_interface_type(named_type) or field_name[0:9] == '_incoming' or field_name[0:9] == '_outgoing':
                 continue
             filter_name = f'_FilterFor{capitalize(named_type.name)}'
             _filter = schema.type_map[filter_name]
@@ -619,17 +624,72 @@ def get_field_annotations(field: GraphQLField):
 def add_edge_objects(schema: GraphQLSchema):
     make = ''
     for _type in schema.type_map.values():
-        if not is_db_schema_defined_type(_type) or is_interface_type(_type):
+        if not is_db_schema_defined_type(_type):
             continue
-        connected_types = schema.get_possible_types(_type) if is_interface_type(_type) else [_type]
         for field_name, field in _type.fields.items():
             inner_field_type = get_named_type(field.type)
             if field_name.startswith('_') or is_enum_or_scalar(inner_field_type):
                 continue
-            for t in connected_types:
-                edge_from = f'{capitalize(field_name)}EdgeFrom{t.name}'
-                annotations = get_field_annotations(field)
-                make += f'type _{edge_from} {{id:ID! source: {t.name}! target: {inner_field_type}! {annotations}}}\n'
+            edge_from = f'{capitalize(field_name)}EdgeFrom{_type.name}'
+            annotations = get_field_annotations(field)
+            type_type_str = 'type'
+            implements_str = ''
+            if is_interface_type(_type):
+                type_type_str = 'interface'
+            elif hasattr(_type, 'interfaces') and _type.interfaces:
+                valid_interfaces = []
+                for interface in _type.interfaces:
+                    if field_name in interface.fields.keys():
+                        valid_interfaces.append(interface.name)
+                if valid_interfaces:
+                    implements_str = f'implements '
+                    implements_str += ' & '.join([f'_{capitalize(field_name)}EdgeFrom{interface}' for interface in valid_interfaces])
+            make += f'{type_type_str} _{edge_from} {implements_str}{{id:ID! source: {_type.name}! target: {inner_field_type}! {annotations}}}\n'
+
+
+    schema = add_to_schema(schema, make)
+    return schema
+
+
+def add_fields_for_edge_types(schema: GraphQLSchema, reverse):
+    make = ''
+    for _type in schema.type_map.values():
+        if not is_db_schema_defined_type(_type):
+            continue
+        for field_name, field in _type.fields.items():
+            inner_field_type = get_named_type(field.type)
+            if field_name.startswith('_') or is_enum_or_scalar(inner_field_type):
+                continue
+
+            edge_from = f'{capitalize(field_name)}EdgeFrom{_type.name}'
+            edge_type = schema.get_type('_'+edge_from)
+            full_type = copy_wrapper_structure(edge_type, field.type)
+            type_type_str = 'type'
+            if is_interface_type(_type):
+                type_type_str = 'interface'
+            make += f'extend {type_type_str} {_type.name} {{ _outgoing{capitalize(field_name)}Edges: {full_type} }}\n'
+
+            if reverse:
+                directives = {}
+                if hasattr(field, 'ast_node') and field.ast_node is not None:
+                    directives = {directive.name.value: directive for directive in field.ast_node.directives}
+                    
+                if hasattr(_type, 'interfaces'):
+                    for interface in _type.interfaces:
+                        if field_name in interface.fields.keys():
+                            directives = {**directives, **{directive.name.value: directive for directive in interface.fields[field_name].ast_node.directives}}
+
+                if 'uniqueForTarget' in directives:
+                    edge_to = edge_type
+                else:
+                    edge_to = GraphQLList(edge_type)
+
+                inner_connected_types = schema.get_possible_types(inner_field_type) if is_interface_type(inner_field_type) else [inner_field_type]
+                for inner_t in inner_connected_types:
+                    type_type_str = 'type'
+                    if is_interface_type(inner_t):
+                        type_type_str = 'interface'
+                    make += f'extend {type_type_str} {inner_t.name} {{ _incoming{edge_from}: {edge_to} }}\n'
 
     schema = add_to_schema(schema, make)
     return schema

--- a/graphql-resolver-generator/generator.py
+++ b/graphql-resolver-generator/generator.py
@@ -40,20 +40,23 @@ def generate(input_file, output_dir):
                 'name': camelCase(type_name),
                 'fields': [],
                 'edgeFields': [],
+                'edgeFieldEndpoints': [],
                 'DateTime': [],
                 'hasKeyDirective': f'_KeyFor{type_name}' in schema.type_map.keys()
             }
             # add object fields
             for field_name, field_type in _type.fields.items():
                 inner_field_type = get_named_type(field_type.type)
-                if is_schema_defined_object_type(inner_field_type) or is_interface_type(inner_field_type):
+                if field_name.startswith('_incoming') or field_name.startswith('_outgoing'):
+                    t['edgeFields'].append(field_name)
+                elif is_schema_defined_object_type(inner_field_type) or is_interface_type(inner_field_type):
                     t['fields'].append(field_name)
                 if inner_field_type.name == 'DateTime':
                     t['DateTime'].append(field_name)
                 if field_name[0] == '_':
                     continue
                 if is_schema_defined_object_type(inner_field_type) or is_interface_type(inner_field_type):
-                    t['edgeFields'].append((pascalCase(field_name), inner_field_type))
+                    t['edgeFieldEndpoints'].append((pascalCase(field_name), inner_field_type))
 
             sort_before_rendering(t)
             data['types'].append(t)

--- a/graphql-resolver-generator/resources/resolver.template
+++ b/graphql-resolver-generator/resources/resolver.template
@@ -76,7 +76,7 @@ const resolvers = {
     ${type['Name']}: {
         id: (parent, args, context, info) => parent._id,
         % for field in type['fields']:
-        % if field[0:9] == '_outgoing' or field[0:9] == '_incoming':
+        % if len(field) >= 8 and (field[0:9] == '_outgoing' or field[0:9] == '_incoming'):
         ${field}: async (parent, args, context, info) =>
             await driver.getEdge(parent, args, info),
         % else:

--- a/graphql-resolver-generator/resources/resolver.template
+++ b/graphql-resolver-generator/resources/resolver.template
@@ -68,8 +68,13 @@ const resolvers = {
     ${type['Name']}: {
         id: (parent, args, context, info) => parent._id,
         % for field in type['fields']:
-        ${field}: async (parent, args, context, info) =>
+        % if field[0:9] == '_outgoing' or field[0:9] == '_incoming':
+            ${field}: async (parent, args, context, info) =>
             await driver.getEdge(parent, args, info),
+        % else:
+        ${field}: async (parent, args, context, info) =>
+            await driver.getEdgeEndpoint(parent, args, info),
+        % endif
         % endfor
         % for field in type['DateTime']:
         ${field}: async (parent, args, context, info) => new Date(parent.${field}),

--- a/graphql-resolver-generator/resources/resolver.template
+++ b/graphql-resolver-generator/resources/resolver.template
@@ -113,9 +113,16 @@ const resolvers = {
 % endfor
 
 % for interface_name in data['interfaces']:
+    % if interface_name.startswith('_'):
+    ${interface_name}: {
+        __resolveType: (parent, args, context, info) =>
+            '_' + parent._id.split('/')[0]
+    },
+    % else:
     ${interface_name}: {
         __resolveType: (parent, args, context, info) =>
             parent._id.split('/')[0]
     },
+    % endif
 % endfor
 }

--- a/graphql-resolver-generator/resources/resolver.template
+++ b/graphql-resolver-generator/resources/resolver.template
@@ -43,7 +43,7 @@ const resolvers = {
     % endfor
 
     % for type in data['types']:
-        % for field, field_type in type['edgeFields']:
+        % for field, field_type in type['edgeFieldEndpoints']:
         create${field}EdgeFrom${type['Name']}: async (parent, args, context, info) =>
             await driver.createEdge(
                 true,
@@ -76,16 +76,15 @@ const resolvers = {
     ${type['Name']}: {
         id: (parent, args, context, info) => parent._id,
         % for field in type['fields']:
-        % if len(field) >= 8 and (field[0:9] == '_outgoing' or field[0:9] == '_incoming'):
-        ${field}: async (parent, args, context, info) =>
-            await driver.getEdge(parent, args, info),
-        % else:
         ${field}: async (parent, args, context, info) =>
             await driver.getEdgeEndpoint(parent, args, info),
-        % endif
         % endfor
         % for field in type['DateTime']:
         ${field}: async (parent, args, context, info) => new Date(parent.${field}),
+        % endfor
+        % for field in type['edgeFields']:
+        ${field}: async (parent, args, context, info) =>
+            await driver.getEdge(parent, args, info),
         % endfor
     },
 % endfor
@@ -102,7 +101,7 @@ const resolvers = {
 % endfor
 
 % for type in data['types']:
-    % for field, field_type in type['edgeFields']:
+    % for field, field_type in type['edgeFieldEndpoints']:
     _${field}EdgeFrom${type['Name']}: {
         id: (parent, args, context, info) => parent._id,
         source: async (parent, args, context, info) =>

--- a/graphql-resolver-generator/resources/resolver.template
+++ b/graphql-resolver-generator/resources/resolver.template
@@ -21,19 +21,25 @@ const resolvers = {
     % endfor
 
     % for type in data['types']:
+        % if type['Name'][0] != '_':
         listOf${type['Name']}s: async (parent, args, context, info) =>
             await driver.getList(args, info),
+        % endif
     % endfor
 
     % for interface_name in data['interfaces']:
+        % if interface_name[0] != '_':
         listOf${interface_name}s: async (parent, args, context, info) => await driver.getList(args, info),
+        % endif
     % endfor
     },
 
     Mutation: {
     % for type in data['types']:
+        % if type['Name'][0] != '_':
         create${type['Name']}: (parent, args, context, info) =>
             driver.create(true, context, args.data, info.schema.getType('${type['Name']}'), info),
+        % endif
     % endfor
 
     % for type in data['types']:
@@ -53,6 +59,7 @@ const resolvers = {
     % endfor
 
     % for type in data['types']:
+        % if type['Name'][0] != '_':
         update${type['Name']}: async (parent, args, context, info) =>
             driver.update(
                 true,
@@ -61,6 +68,7 @@ const resolvers = {
                 args.data,
                 info.schema.getType('${type['Name']}'),
                 info),
+        % endif
     % endfor
     },
 
@@ -69,7 +77,7 @@ const resolvers = {
         id: (parent, args, context, info) => parent._id,
         % for field in type['fields']:
         % if field[0:9] == '_outgoing' or field[0:9] == '_incoming':
-            ${field}: async (parent, args, context, info) =>
+        ${field}: async (parent, args, context, info) =>
             await driver.getEdge(parent, args, info),
         % else:
         ${field}: async (parent, args, context, info) =>
@@ -83,12 +91,14 @@ const resolvers = {
 % endfor
 
 % for type in data['types']:
+    % if type['Name'][0] != '_':
     _ListOf${type['Name']}s: {
         totalCount: async (parent, args, context, info) =>
             await driver.getTotalCount(parent, args, info),
         isEndOfWholeList: async (parent, args, context, info) =>
             await driver.isEndOfList(parent, args, info),
     },
+    % endif
 % endfor
 
 % for type in data['types']:

--- a/graphql-server/drivers/arangodb/driver.js
+++ b/graphql-server/drivers/arangodb/driver.js
@@ -251,10 +251,9 @@ function getObjectOrInterfaceFields(type) {
  */
 function convertToInputAppendString(doc) {
     ret = ''
-    if (doc != null && doc.size > 0) {
+    if (doc != null && Object.keys(doc).length > 0) {
         ret = JSON.stringify(doc);
-        ret[0] = ',';
-        ret = ret - slice(0, -1);
+        ret = ', ' + ret.slice(1, -1);
     }
     return ret;
 }
@@ -352,7 +351,7 @@ async function getEdge(parent, args, info) {
     }
     query = query.concat(query_filters);
     query.push(aql`RETURN e`);
-    console.log(aql.join(query));
+
     const cursor = await db.query(aql.join(query));
     if (graphql.isListType(graphql.getNullableType(info.returnType))) {
         return await cursor.all();
@@ -413,11 +412,11 @@ async function create(isRoot, ctxt, data, returnType, info) {
             console.log(value);
 
             // Prepare annotations
-            let annotations = null;
+            let annotations = {};
             if (value['annotations']) {
                 annotations = getScalarsAndEnums(value['annotations'], info.schema.getType("_InputToAnnotate" + edge));
-                annotations['_creationDate'] = date.valueOf();
             }
+            annotations['_creationDate'] = date.valueOf();
 
             if (graphql.isInterfaceType(innerFieldType)) { // interface
                 if (value['connect']) {
@@ -695,11 +694,11 @@ async function update(isRoot, ctxt, id, data, returnType, info) {
             let value = values[i];
 
             // Prepare annotations
-            let annotations = null;
+            let annotations = {};
             if (value['annotations']) {
                 annotations = getScalarsAndEnums(value['annotations'], info.schema.getType("_InputToAnnotate" + edge));
-                annotations['_creationDate'] = date.valueOf();
             }
+            annotations['_creationDate'] = date.valueOf();
 
             if (graphql.isInterfaceType(nestedReturnType)) {
                 // interface field

--- a/graphql-server/drivers/arangodb/driver.js
+++ b/graphql-server/drivers/arangodb/driver.js
@@ -331,13 +331,13 @@ async function getEdge(parent, args, info) {
         if (possible_types.length > 1) query.push(aql`UNION(`);
         for (let i in possible_types) {
             if (i != 0) query.push(aql`,`);
-            let collection = db.collection(possible_types[i].name);
-            query.push(aql`(FOR v,e IN 1..1 ANY ${parent._id} ${collection} RETURN e)`);
+            let collection = db.collection(possible_types[i].name.substr(1));
+            query.push(aql`(FOR v, inner_e IN 1..1 ANY ${parent._id} ${collection} RETURN inner_e)`);
         }
         if (possible_types.length > 1) query.push(aql`)`);
 
     } else {
-        let collection = db.collection(return_type.name);
+        let collection = db.edgeCollection(return_type.name.substr(1));
         query.push(aql`FOR v, e IN 1..1 ANY ${parent._id} ${collection}`);
     }
 
@@ -352,7 +352,7 @@ async function getEdge(parent, args, info) {
     }
     query = query.concat(query_filters);
     query.push(aql`RETURN e`);
-
+    console.log(aql.join(query));
     const cursor = await db.query(aql.join(query));
     if (graphql.isListType(graphql.getNullableType(info.returnType))) {
         return await cursor.all();

--- a/graphql-server/tests/generation-tools.js
+++ b/graphql-server/tests/generation-tools.js
@@ -64,7 +64,6 @@ function generateInput(type, depth=0, limit=3, include_optional){
                 value = {'connect' : `Dummy/${faker.random.number()}` }
             } else {
                 let keys = [];
-                let annotations = null
                 value = {}
                 for (let k in named_type._fields) {
                     if (k == 'connect') {

--- a/graphql-server/tests/generation-tools.js
+++ b/graphql-server/tests/generation-tools.js
@@ -64,9 +64,15 @@ function generateInput(type, depth=0, limit=3, include_optional){
                 value = {'connect' : `Dummy/${faker.random.number()}` }
             } else {
                 let keys = [];
-                for(let k in named_type._fields){
-                    if(k == 'connect'){
-                        continue; // don't use connect
+                let annotations = null
+                value = {}
+                for (let k in named_type._fields) {
+                    if (k == 'connect') {
+                        continue; // don't use connect 
+                    }
+                    if (k == 'annotations') {
+                        value['annotations'] = generateInput(named_type._fields['annotations'].type, depth + 1, limit, include_optional);
+                        continue; // don't use anntations as key 
                     }
                     keys.push(k); // add a create or createX field
                 }
@@ -74,7 +80,6 @@ function generateInput(type, depth=0, limit=3, include_optional){
                 let key = faker.random.arrayElement(keys);
                 let t = named_type._fields[key].type;
 
-                value = {}
                 value[key] = generateInput(t, depth + 1, limit, include_optional);
             }
         }


### PR DESCRIPTION
Querying edges (including annotations) is now possible. 
Client-test should now work with annotations (hence the change to generation-tools).
Old edgeFields have internally been renamed edgeFieldEndpoints, and edgeFields are now used for fields containing incoming/outgoing edges (instead of the source/target of an edge) (edge_objects and edge_types in utils. Should maybe change that?).
Note that resolvers for list and updates of types starting with '_' is currently fully disabled (should only affect edges), as this is a separate issue.

@hartig want to take a look if you think there is something missing (if you got the time during all the grading), or should we ask @keski to review?
