### PR TITLE
Filters occuring in subfields nolonger causes errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 **v0.1.1, released on ???**
 * New feature: Edge annotations can now be set when creating and/or updating objects. See: https://github.com/LiUGraphQL/woo.sh/issues/24
 * Bug fix: Default values missing from field arguments is now fixed.
+* Bug fix: Filters occuring in subfields nolonger causes errors.
 
 **v0.1.0, released on June 09, 2020**
 * Initial version


### PR DESCRIPTION
@rcapshaw I'm a bit hesitant to push this directly to master as I know you are working on the next release and I don't know if this impacts anything for you. 
If you have the opportunity and if it has no major impact for the release/you, can you please merge this before the release (to get rid of one more bug before the release). Else we can (hopefully) wait with this until after the release and hope no one actually uses the filtering feature on sub-fields :S