### PR TITLE
Add a dummy field _dummy to all types without visible fields 

### DIFF
--- a/graphql-api-generator/utils/utils.py
+++ b/graphql-api-generator/utils/utils.py
@@ -248,10 +248,11 @@ def add_input_to_create(schema: GraphQLSchema):
         if not is_db_schema_defined_type(_type) or is_interface_type(_type):
             continue
         make += f'\nextend input _InputToCreate{_type.name} {{\n'
+        num_fields = 0
         for field_name, field in _type.fields.items():
             if field_name == 'id' or field_name[0] == '_':
                 continue
-
+            num_fields += 1
             inner_field_type = get_named_type(field.type)
 
             if is_enum_or_scalar(inner_field_type):
@@ -261,6 +262,8 @@ def add_input_to_create(schema: GraphQLSchema):
                 connect_name = f'_InputToConnect{capitalize(field_name)}Of{_type.name}'
                 connect = copy_wrapper_structure(schema.type_map[connect_name], field.type)
                 make += f'   {field_name}: {connect} \n'
+        if num_fields == 0:
+            make += f'   _dummy: String \n'
         make += '}\n'
     schema = add_to_schema(schema, make)
     return schema
@@ -392,11 +395,12 @@ def add_input_update(schema: GraphQLSchema):
     for _type in schema.type_map.values():
         if not is_db_schema_defined_type(_type) or is_interface_type(_type):
             continue
+        num_fields = 0
+        update_name = f'_InputToUpdate{_type.name}'
         for field_name, field in _type.fields.items():
             if field_name == 'id' or field_name[0] == '_':
                 continue
-
-            update_name = f'_InputToUpdate{_type.name}'
+            num_fields += 1
             f_type = get_nullable_type(field.type)
             inner_field_type = get_named_type(f_type)
 
@@ -407,6 +411,8 @@ def add_input_update(schema: GraphQLSchema):
                 connect_name = f'_InputToConnect{capitalize(field_name)}Of{_type.name}'
                 connect = copy_wrapper_structure(schema.get_type(connect_name), f_type)
                 make += f'extend input {update_name} {{ {field_name}: {connect} }} \n'
+        if num_fields == 0:
+            make += f'extend input {update_name} {{ _dummy: String }} \n'
     schema = add_to_schema(schema, make)
     return schema
 
@@ -885,6 +891,9 @@ def get_field_directives(field_name, _type, schema):
     :param schema:
     :return string:
     """
+
+    if field_name == '_dummy':
+        return ''
 
     output = ''
 


### PR DESCRIPTION
Changes needed for #73. Adds in a simple, hard-coded dummy field to any "empty" types.