### PR TITLE
#89: Check for existence of the database before attempting to drop it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.1.2, to be released on ???**
+* Bug fix: Checks for existence of the database before attempting to drop it. See: https://github.com/LiUGraphQL/woo.sh/issues/89
+
 **v0.1.1, released on June 23, 2020**
 * New feature: Edge annotations can now be set when creating and/or updating objects. See: https://github.com/LiUGraphQL/woo.sh/issues/24
 * New feature: Incoming and outgoing edges (with annotations) can now be queried (not just the sources and targets). See: https://github.com/LiUGraphQL/woo.sh/issues/31

--- a/graphql-server/drivers/arangodb/driver.js
+++ b/graphql-server/drivers/arangodb/driver.js
@@ -77,7 +77,8 @@ async function init(args){
     console.info(`ArangoDB is now available at ${url}`);
 
     // if drop is set
-    if(drop) {
+	dblist = await db.listDatabases();
+    if(drop && dblist.includes(dbName)) {
         await db.dropDatabase(dbName).then(
             () => console.info(`Database ${dbName} dropped.`),
             (err) => console.error(err)


### PR DESCRIPTION
This should address https://gitlab.com/spirit-tools/mediator-service/-/issues/84 (as well as #89) by adding in a check to the driver to see whether the database exists yet before trying to drop it.

@hartig @keski 