### PR TITLE
Minor edge validation optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 **v0.1.2, to be released on ???**
 * Bug fix: Checks for existence of the database before attempting to drop it. See: https://github.com/LiUGraphQL/woo.sh/issues/89
+* New feature: Changed Edge validation behaviour to not check for existance of documents created in the same mutation. See: https://github.com/LiUGraphQL/woo.sh/pull/98
 
 **v0.1.1, released on June 23, 2020**
 * New feature: Full support for edge annotations is now implemented, including querying (see https://github.com/LiUGraphQL/woo.sh/issues/31), updating and creation on edge/object creation.


### PR DESCRIPTION
Tries to optimize when edge validations are enforced, by only checking if source/target exists when the driver cannot already easily guarantee that they already exists. I.e. when create edge is called from `create` and the `create` was used in the graphQL, we skip both validations. When `connect` was used, the source validation is skipped.

@keski Do you see any problems/anything I have missed with this minor optimization? From the testing I did it seems to be working, and reduced the time spent on edge validation quite significantly in optimal cases, and not at all in worst case scenarions.

Are there any other simple optimizations you can see?