### PR TITLE
64 Driver Parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 **v0.1.4, to be released on ???**
+* New feature: Generation of the driver now takes the choosen configuration into account; see: https://github.com/LiUGraphQL/woo.sh/issues/64
 
 **v0.1.3, released on August 28, 2020**
 * New feature: Support for multiple *dependent* mutation operations within a single mutation request; https://github.com/LiUGraphQL/woo.sh/issues/52

--- a/graphql-resolver-generator/generator.py
+++ b/graphql-resolver-generator/generator.py
@@ -1,7 +1,6 @@
 import argparse
 import yaml
 
-import yaml
 from graphql import build_schema, is_object_type, get_named_type, is_interface_type, assert_valid_schema, is_input_type
 from mako.template import Template
 

--- a/graphql-server/drivers/arangodb/driver.js
+++ b/graphql-server/drivers/arangodb/driver.js
@@ -347,7 +347,9 @@ function createEdge(isRoot, ctxt, varOrSourceID, sourceType, sourceField, varOrT
 
     // define doc
     const doc = annotations;
+    // #IF field_for_creation_date
     doc['_creationDate'] = new Date().valueOf();
+    // #ENDIF
     const docVar = addParameterVar(ctxt, createParamVar(ctxt), doc);
 
     // validate edge
@@ -387,7 +389,9 @@ function create(isRoot, ctxt, data, returnType, info, resVar = null) {
 
     // get non-object fields, add creation date and add as parameter
     const doc = getScalarsAndEnums(data, returnType);
+    // #IF field_for_creation_date
     doc['_creationDate'] = new Date().valueOf();
+    // #ENDIF
     const docVar = addParameterVar(ctxt, createParamVar(ctxt), doc);
 
     // create a new resVar if not defined by the calling function, resVar is the source vertex for all edges
@@ -474,8 +478,10 @@ function updateEdge(isRoot, ctxt, id, data, edgeName, inputToUpdateType, info, r
     ctxt.trans.code.push(`\n\t/* update edge ${edgeName} */`);
 
     // define doc
-    const doc = getScalarsAndEnums(data, info.schema.getType(inputToUpdateType));;
+    const doc = getScalarsAndEnums(data, info.schema.getType(inputToUpdateType));
+    // #IF field_for_last_update_date
     doc['_lastUpdateDate'] = new Date().valueOf();
+    // #ENDIF
     const docVar = addParameterVar(ctxt, createParamVar(ctxt), doc);
     const idVar = addParameterVar(ctxt, createParamVar(ctxt), id);
 
@@ -642,7 +648,9 @@ function update(isRoot, ctxt, varOrID, data, returnType, info, resVar = null) {
 
     // get non-object fields, add creation date and add as parameter
     let doc = getScalarsAndEnums(data, returnType);
+    // #IF field_for_last_update_date
     doc['_lastUpdateDate'] = new Date().valueOf();
+    // #ENDIF
     let docVar = addParameterVar(ctxt, createParamVar(ctxt), doc);
 
     // create a new resVar if not defined by the calling function, resVar is the source vertex for all edges

--- a/graphql-server/drivers/driver_parser.py
+++ b/graphql-server/drivers/driver_parser.py
@@ -1,0 +1,45 @@
+import argparse
+import yaml
+
+
+def parse(input_file, output_dir, config: dict):
+    # Simple function to parse a file to remove specific parts depending on the choosen config
+
+    input_f = open(input_file, 'r')
+
+    output_f = open(output_dir+'\\driver.js',"w")
+
+    if_stack = [True]
+
+    for line in input_f.readlines():
+        if line.strip().startswith('// #'):
+            if line.strip().startswith('// #ENDIF'):
+                if_stack.pop()
+            if line.strip().startswith('// #IF'):
+                sub_line = line.strip()[7:]
+                if_stack.append(config.get('generation').get(sub_line))
+        elif if_stack[-1]:
+            output_f.write(line)
+
+    output_f.close()
+    input_f.close()
+
+def cmd(args):
+    # load config
+    config = {}
+    if args.config:
+        with open(args.config) as f:
+            config = yaml.safe_load(f)
+
+    parse(args.input, args.output, config)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--input', type=str, required=True,
+                        help='Driver file')
+    parser.add_argument('--output', type=str,
+                        help='Output directory for new driver file')
+    parser.add_argument('--config', type=str,
+                        help='Path to configuration file')
+    cmd(parser.parse_args())

--- a/woo.sh
+++ b/woo.sh
@@ -473,3 +473,11 @@ python3 generator.py \
     --output ${output_dir} \
     --config ${config_file}
 cd ..
+
+# parse driver
+cd ./graphql-server/drivers
+python3 driver_parser.py \
+    --input ${driver_dir}/driver.js \
+    --output ${output_dir} \
+    --config ${config_file}
+cd ..


### PR DESCRIPTION
driver.js generation should now (be able to) reflect configuration changed.

Both delete-functions (and maybe update-functions too?) should likely be marked in similar fashion as the `creationDate` and `lastUpdateDate`. To completely turn them of when the api+resolver for them are not generated.

Anyone have any comments on these changes? @hartig @keski @rcapshaw 
Should currently not impact anything for spirit.

Closes #64 
